### PR TITLE
Enabled to be detected multiple words.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,11 @@ Via `.textlintrc`(Recommended)
         {
           "pattern": "ふいんき",
           "message": "「ふいんき」ではなく「ふんいき」です。"
-        }
+        },
+        {
+          "pattern": "うる覚え,布団をひく",
+          "message": "誤った言葉です。"
+        },
       ]
     }
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,32 +17,35 @@ const reporter: TextlintRuleReporter = (context, userOptions) => {
       const surfaceForms = tokens.map(({ surface_form }) => surface_form);
 
       options.dictionary.forEach(({ pattern, message }) => {
-        let currentPattern = pattern;
-        let index = 0;
+        let splittedPattern = pattern.split(',');
+        for(let currentPattern of splittedPattern) {
+          let duplicatedCurrentPattern = currentPattern;
+          let index = 0;
 
-        surfaceForms.forEach((surfaceForm) => {
-          const surfaceFormLength = surfaceForm.length;
+          surfaceForms.forEach((surfaceForm) => {
+            const surfaceFormLength = surfaceForm.length;
 
-          index += surfaceFormLength;
+            index += surfaceFormLength;
 
-          if (currentPattern.startsWith(surfaceForm)) {
-            currentPattern = currentPattern.slice(surfaceFormLength);
+            if (duplicatedCurrentPattern.startsWith(surfaceForm)) {
+              duplicatedCurrentPattern = duplicatedCurrentPattern.slice(surfaceFormLength);
 
-            if (currentPattern !== "") {
-              return;
+              if (duplicatedCurrentPattern !== "") {
+                return;
+              }
+
+              const ruleError = new RuleError(
+                message ??
+                  `「${currentPattern}」はユーザー辞書によって禁止されています。`,
+                { index: index - currentPattern.length }
+              );
+
+              report(node, ruleError);
             }
 
-            const ruleError = new RuleError(
-              message ??
-                `「${pattern}」はユーザー辞書によって禁止されています。`,
-              { index: index - pattern.length }
-            );
-
-            report(node, ruleError);
-          }
-
-          currentPattern = pattern;
-        });
+            duplicatedCurrentPattern = currentPattern;
+          });
+        }
       });
     },
   };

--- a/test/index-test.ts
+++ b/test/index-test.ts
@@ -19,6 +19,10 @@ tester.run(
               pattern: "ふいんき",
               message: "「ふいんき」ではなく「ふんいき」です。",
             },
+            {
+              pattern: "うる覚え,布団をひく",
+              message: "誤った言葉です。",
+            },
           ],
         },
       },
@@ -48,6 +52,21 @@ tester.run(
             line: 1,
             column: 1,
           },
+        ],
+      },
+      {
+        text: "うる覚えですが布団をひくという言葉があったはずです。",
+        errors: [
+          {
+            message: "誤った言葉です。",
+            line: 1,
+            column: 1,
+          },
+          {
+            message: "誤った言葉です。",
+            line: 1,
+            column: 8,
+          }
         ],
       },
     ],


### PR DESCRIPTION
In the conventional format of `rules`, it is necessary to increase the `pattern` for each word to be detected.
Therefore, when many words are detected, the number of lines in the `rule` increased, and it make to be difficult to read.
To solve this problem, we made it possible to detect many words in a `rule`.